### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     zlib1g-dev
 
-RUN pyenv install 3.7 && \
-    pyenv install 3.8 && \
+RUN pyenv install 3.8 && \
     pyenv install 3.9 && \
     pyenv install 3.10 && \
     pyenv install 3.11 && \


### PR DESCRIPTION
Before we do this we probably want to tag an older release so stable branches don't break.
